### PR TITLE
fix: Use new type for DataGrid ColDef

### DIFF
--- a/src/examples/DataGridExample/DataGridExample.tsx
+++ b/src/examples/DataGridExample/DataGridExample.tsx
@@ -1,8 +1,8 @@
 import React, { FunctionComponent, useEffect, useRef } from "react";
 
-import { DataGrid, ColDef, ValueGetterParams, GridApi } from "@material-ui/data-grid";
+import { DataGrid, GridColDef, ValueGetterParams, GridApi } from "@material-ui/data-grid";
 
-const columns: ColDef[] = [
+const columns: GridColDef[] = [
   { field: "id", headerName: "ID", width: 70 },
   { field: "firstName", headerName: "First name", width: 130 },
   { field: "lastName", headerName: "Last name", width: 130 },

--- a/src/pages/EventsList.tsx
+++ b/src/pages/EventsList.tsx
@@ -1,13 +1,13 @@
 import React, { FunctionComponent, useEffect, useState } from "react";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
-import { DataGrid, ColDef } from "@material-ui/data-grid";
+import { DataGrid, GridColDef } from "@material-ui/data-grid";
 import EditIcon from "@material-ui/icons/Edit";
 import DeleteIcon from "@material-ui/icons/Delete";
 import IconButton from "@material-ui/core/IconButton";
 import { Tag, WeBetEvent } from "../models";
 
-const columns: ColDef[] = [
+const columns: GridColDef[] = [
   { field: "name", headerName: "Name", flex: 1 },
   { field: "start_time", headerName: "Start Time", flex: 0.75 },
   { field: "end_time", headerName: "End Time", flex: 0.75 },


### PR DESCRIPTION
In `@material-ui/data-grid` [v4.0.0-alpha.21](https://github.com/mui-org/material-ui-x/pull/1069), types were renamed, including ColDef to GridColDef. So we need to import and use that type now instead