### PR TITLE
Show selected item in side menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,7 @@ import { Routes } from "./Router";
 import { BrowserRouter } from "react-router-dom";
 import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
 import CssBaseline from "@material-ui/core/CssBaseline";
-import { SideMenu } from "./components/SideMenu/SideMenu";
-
+import SideMenu from "./components/SideMenu";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/src/components/SideMenu/SideMenu.test.tsx
+++ b/src/components/SideMenu/SideMenu.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { SideMenu } from "./SideMenu";
-import { MemoryRouter } from 'react-router-dom';
+import SideMenu from "./SideMenu";
+import { MemoryRouter } from "react-router-dom";
 
 describe("SideMenu", () => {
   it("renders the Home Button in the SideMenu", () => {

--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -30,7 +30,7 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 );
 
-interface PageLinkProps extends Pick<RouterLinkProps, "to">, Omit<ListItemTextProps, "classes"> {
+interface PageLinkProps extends Pick<RouterLinkProps, "to">, Pick<ListItemProps, "selected"> {
   listItemClassName?: ListItemProps["className"];
   listItemTextClassName?: ListItemTextProps["className"];
 }
@@ -40,13 +40,17 @@ const PageLink: FunctionComponent<PageLinkProps> = ({
   children,
   listItemClassName,
   listItemTextClassName,
-  ...listItemTextProps
+  selected,
 }) => {
   return (
-    <ListItem button to={to} component={RouterLink} className={listItemClassName}>
-      <ListItemText className={listItemTextClassName} {...listItemTextProps}>
-        {children}
-      </ListItemText>
+    <ListItem
+      button
+      to={to}
+      component={RouterLink}
+      className={listItemClassName}
+      selected={selected}
+    >
+      <ListItemText className={listItemTextClassName}>{children}</ListItemText>
     </ListItem>
   );
 };

--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -1,6 +1,7 @@
 import List from "@material-ui/core/List";
 import ListItem, { ListItemProps } from "@material-ui/core/ListItem";
 import ListItemText, { ListItemTextProps } from "@material-ui/core/ListItemText";
+import ListItemIcon from "@material-ui/core/ListItemIcon";
 import Drawer from "@material-ui/core/Drawer";
 import React, { FunctionComponent } from "react";
 import { Link as RouterLink, LinkProps as RouterLinkProps } from "react-router-dom";
@@ -31,6 +32,7 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 interface PageLinkProps extends Pick<RouterLinkProps, "to">, Pick<ListItemProps, "selected"> {
+  icon?: JSX.Element | null;
   listItemClassName?: ListItemProps["className"];
   listItemTextClassName?: ListItemTextProps["className"];
 }
@@ -41,7 +43,12 @@ const PageLink: FunctionComponent<PageLinkProps> = ({
   listItemClassName,
   listItemTextClassName,
   selected,
+  icon,
 }) => {
+  if (icon === undefined) {
+    icon = null;
+  }
+
   return (
     <ListItem
       button
@@ -50,6 +57,7 @@ const PageLink: FunctionComponent<PageLinkProps> = ({
       className={listItemClassName}
       selected={selected}
     >
+      <ListItemIcon>{icon}</ListItemIcon>
       <ListItemText className={listItemTextClassName}>{children}</ListItemText>
     </ListItem>
   );

--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -2,8 +2,11 @@ import List from "@material-ui/core/List";
 import ListItem, { ListItemProps } from "@material-ui/core/ListItem";
 import ListItemText, { ListItemTextProps } from "@material-ui/core/ListItemText";
 import ListItemIcon from "@material-ui/core/ListItemIcon";
+import EventIcon from "@material-ui/icons/Event";
+import HomeIcon from "@material-ui/icons/Home";
+import TableChartIcon from "@material-ui/icons/TableChart";
 import Drawer from "@material-ui/core/Drawer";
-import React, { FunctionComponent } from "react";
+import React, { Fragment, FunctionComponent } from "react";
 import { Link as RouterLink, LinkProps as RouterLinkProps } from "react-router-dom";
 import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
 
@@ -63,6 +66,88 @@ const PageLink: FunctionComponent<PageLinkProps> = ({
   );
 };
 
+interface MenuItem {
+  name: string;
+  path: string;
+  icon?: JSX.Element;
+  children?: MenuItem[];
+}
+
+const menuItems: MenuItem[] = [
+  {
+    name: "Home",
+    path: "/",
+    icon: <HomeIcon />,
+  },
+  {
+    name: "Events",
+    path: "/events",
+    icon: <EventIcon />,
+  },
+  {
+    name: "Examples",
+    path: "/examples",
+    children: [
+      {
+        name: "DataGrid",
+        path: "/examples/data-grid",
+        icon: <TableChartIcon />,
+      },
+    ],
+  },
+];
+
+interface MenuItemsProps {
+  menuItems: MenuItem[];
+  currentPageLocation: string;
+  nestedListClassName: string;
+}
+
+const MenuItems: FunctionComponent<MenuItemsProps> = ({
+  menuItems,
+  currentPageLocation,
+  nestedListClassName,
+}) => {
+  const menuItemLinks = menuItems.map((menuItem) => {
+    let nestedLinks: JSX.Element | null = null;
+    if (menuItem.children) {
+      const childLinks = menuItem.children.map((nestedMenuItem) => {
+        const selected = nestedMenuItem.path === currentPageLocation;
+
+        return (
+          <PageLink
+            to={nestedMenuItem.path}
+            listItemClassName={nestedListClassName}
+            key={nestedMenuItem.name}
+            icon={nestedMenuItem.icon}
+            selected={selected}
+          >
+            {nestedMenuItem.name}
+          </PageLink>
+        );
+      });
+
+      nestedLinks = (
+        <List component="div" disablePadding>
+          {childLinks}
+        </List>
+      );
+    }
+
+    const selected = menuItem.path === currentPageLocation;
+    return (
+      <Fragment key={menuItem.name}>
+        <PageLink key={menuItem.name} to={menuItem.path} icon={menuItem.icon} selected={selected}>
+          {menuItem.name}
+        </PageLink>
+        {nestedLinks}
+      </Fragment>
+    );
+  });
+
+  return <>{menuItemLinks}</>;
+};
+
 export function SideMenu() {
   const classes = useStyles();
   // const [open, setOpen] = React.useState(false);
@@ -86,14 +171,11 @@ export function SideMenu() {
       }}
     >
       <List>
-        <PageLink to="/">Home</PageLink>
-        <PageLink to="/events">Events</PageLink>
-        <PageLink to="/examples">Examples</PageLink>
-        <List component="div" disablePadding>
-          <PageLink to="/examples/data-grid" listItemClassName={classes.nested}>
-            DataGrid
-          </PageLink>
-        </List>
+        <MenuItems
+          menuItems={menuItems}
+          currentPageLocation={"/"}
+          nestedListClassName={classes.nested}
+        />
       </List>
     </Drawer>
   );

--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -7,7 +7,12 @@ import HomeIcon from "@material-ui/icons/Home";
 import TableChartIcon from "@material-ui/icons/TableChart";
 import Drawer from "@material-ui/core/Drawer";
 import React, { Fragment, FunctionComponent } from "react";
-import { Link as RouterLink, LinkProps as RouterLinkProps } from "react-router-dom";
+import {
+  Link as RouterLink,
+  LinkProps as RouterLinkProps,
+  withRouter,
+  RouteComponentProps,
+} from "react-router-dom";
 import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
 
 const drawerWidth = 240;
@@ -148,8 +153,10 @@ const MenuItems: FunctionComponent<MenuItemsProps> = ({
   return <>{menuItemLinks}</>;
 };
 
-export function SideMenu() {
+const SideMenu: FunctionComponent<RouteComponentProps> = ({ location }) => {
   const classes = useStyles();
+  const currentPageLocation = location.pathname;
+
   // const [open, setOpen] = React.useState(false);
 
   // const handleDrawerOpen = () => {
@@ -173,12 +180,13 @@ export function SideMenu() {
       <List>
         <MenuItems
           menuItems={menuItems}
-          currentPageLocation={"/"}
+          currentPageLocation={currentPageLocation}
           nestedListClassName={classes.nested}
         />
       </List>
     </Drawer>
   );
-}
+};
+SideMenu.displayName = "SideMenu";
 
-export default SideMenu;
+export default withRouter(SideMenu);

--- a/src/components/SideMenu/index.ts
+++ b/src/components/SideMenu/index.ts
@@ -1,1 +1,2 @@
-export * from './SideMenu'
+export { default } from "./SideMenu"; // Export the default export from SideMenu as this files default
+export * from "./SideMenu"; // Export everything else


### PR DESCRIPTION
Adds the ability for the side menu to mark the button corresponding to the current page as selected. We accomplish this by wrapping the SideMenu in React router's `withRouter` HoC that provides routing information to the wrapped component. From there we can check the `location` prop for it's `pathname` property to determine the path for the page we're currently on. This is then passed to the new MenuItems component which checks the pathname vs the path for on each menu item object. When the paths match, that PageLink is marked as selected.

Closes #19 