### PR TITLE
Misc fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "version": "0.1.0",
-      "hasInstallScript": true,
       "dependencies": {
         "@material-ui/core": "^4.11.4",
         "@material-ui/data-grid": "^4.0.0-alpha.27",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "postinstall": "husky install"
+    "prepare": "husky install"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -10,13 +10,13 @@ export function Routes() {
       <Route exact path="/">
         <Home />
       </Route>
-      <Route path="/events">
+      <Route exact path="/events">
         <EventList />
       </Route>
       <Route exact path="/examples">
         <Redirect to="/examples/data-grid" />
       </Route>
-      <Route path="/examples/data-grid">
+      <Route exact path="/examples/data-grid">
         <DataGridExample />
       </Route>
     </Switch>

--- a/src/examples/DataGridExample/DataGridExample.tsx
+++ b/src/examples/DataGridExample/DataGridExample.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useEffect, useRef } from "react";
 
-import { DataGrid, GridColDef, ValueGetterParams, GridApi } from "@material-ui/data-grid";
+import { DataGrid, GridColDef, GridApi, useGridSlotComponentProps } from "@material-ui/data-grid";
 
 const columns: GridColDef[] = [
   { field: "id", headerName: "ID", width: 70 },
@@ -18,7 +18,7 @@ const columns: GridColDef[] = [
     description: "This column has a value getter and is not sortable.",
     sortable: false,
     width: 160,
-    valueGetter: (params: ValueGetterParams) =>
+    valueGetter: (params) =>
       `${params.getValue("firstName") || ""} ${params.getValue("lastName") || ""}`,
   },
 ];
@@ -41,7 +41,7 @@ export const DataGridExample: FunctionComponent = (props) => {
   // Example showing how we can use the apiRef to modify the DataGrid;
   useEffect(() => {
     const timeoutId = setTimeout(() => {
-      apiRef.current?.updateColumn({
+      apiRef?.current?.updateColumn({
         field: "firstName",
         headerName: "First Name",
       });
@@ -60,10 +60,12 @@ export const DataGridExample: FunctionComponent = (props) => {
           // Normally it's not good to provide an inline declared component as a prop, since it will
           // get redefined each render of TableExample, but since this "Toolbar" component is not
           // actually rendering anything and instead is returning null, it's fine
-          Toolbar: (params) => {
+          Toolbar: () => {
+            const gridSlotComponentProps = useGridSlotComponentProps();
+
             // Only set the ref once, if its already, set, we don't need to reset it
-            if (!apiRef.current && params.api.current) {
-              apiRef.current = params.api.current;
+            if (!apiRef?.current && gridSlotComponentProps?.apiRef) {
+              apiRef.current = gridSlotComponentProps.apiRef.current;
             }
             return null;
           },


### PR DESCRIPTION
**chore: Use prepare instead of postinstall for husk**
Husky's most up to date docs suggest using "prepare" instead of "postinstall" so that it doesn't get run when a package using husky is install as a dependency in another package: https://typicode.github.io/husky/#/?id=install


**fix: Make routes exact**
Ensures we only render a route when its path is provided exactly as set in the component

**fix: DataGridExample**
To work with newer `@material-ui/data-grid` versions:
- Allow valueGetter function params to be inferred so that we ensure it gets appopriately typed to the updated type from GridColDef automatically. The new type is GridValueGetterParams.
- Use hook provided by the package to get the props for the Toolbar grid slot component, since the passed in props were removed in version v4.0.0-alpha.24.