### PR TITLE
Add Event details page

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "trailingComma": "es5",
     "useTabs": false
   },
+  "proxy": "http://localhost:8000",
   "browserslist": {
     "production": [
       ">0.2%",

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -3,6 +3,7 @@ import { Switch, Route, Redirect } from "react-router-dom";
 import { EventList } from "./pages/EventsList";
 import { Home } from "./pages/Home";
 import { DataGridExample } from "./examples/DataGridExample/DataGridExample";
+import { EventDetails } from "./pages/EventDetails";
 
 export function Routes() {
   return (
@@ -12,6 +13,9 @@ export function Routes() {
       </Route>
       <Route exact path="/events">
         <EventList />
+      </Route>
+      <Route exact path="/event/:id">
+        <EventDetails />
       </Route>
       <Route exact path="/examples">
         <Redirect to="/examples/data-grid" />

--- a/src/components/EventCard/EventCard.test.tsx
+++ b/src/components/EventCard/EventCard.test.tsx
@@ -7,7 +7,7 @@ describe("EventCard", () => {
   it("renders the Event name and description", () => {
     render(
       <MemoryRouter>
-        <EventCard eventName="Fake Name" eventDescription="Fake Description" />
+        <EventCard name="Fake Name" description="Fake Description" id={1} />
       </MemoryRouter>
     );
 

--- a/src/components/EventCard/EventCard.tsx
+++ b/src/components/EventCard/EventCard.tsx
@@ -1,10 +1,10 @@
-import Typography from "@material-ui/core/Typography";
 import React, { FunctionComponent } from "react";
-import { useStyles } from "../../useStyle";
+import Button from "@material-ui/core/Button";
 import Card from "@material-ui/core/Card";
 import CardActions from "@material-ui/core/CardActions";
 import CardContent from "@material-ui/core/CardContent";
-import Button from "@material-ui/core/Button";
+import Typography from "@material-ui/core/Typography";
+import { useStyles } from "../../useStyle";
 
 interface EventCardProps {
   name: string;

--- a/src/components/EventCard/EventCard.tsx
+++ b/src/components/EventCard/EventCard.tsx
@@ -7,23 +7,22 @@ import CardContent from "@material-ui/core/CardContent";
 import Button from "@material-ui/core/Button";
 
 interface EventCardProps {
-  eventName: string;
-  eventDescription: string;
-  eventStartDate?: string;
-  eventId?: number;
+  name: string;
+  description: string;
+  startDate?: string;
+  id?: number;
 }
 
-export const EventCard: FunctionComponent<EventCardProps> = (props) => {
-  const { eventName, eventDescription } = props;
+export const EventCard: FunctionComponent<EventCardProps> = ({ name, description, id }) => {
   const classes = useStyles();
   return (
     <Card className={classes.eventCard}>
       <CardContent>
-        <Typography variant="h5" component="h2">
-          {eventName}
+        <Typography variant="h5" component="h3">
+          {name}
         </Typography>
         <Typography variant="body2" color="textSecondary" component="p">
-          {eventDescription}
+          {description}
         </Typography>
       </CardContent>
       <CardActions>

--- a/src/components/EventCards/EventCards.test.tsx
+++ b/src/components/EventCards/EventCards.test.tsx
@@ -1,10 +1,16 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
 import { EventCards } from "./EventCards";
 import { MemoryRouter } from "react-router-dom";
+import { mockEvents } from "../../mockData/mockEvents";
 
 describe("EventCards", () => {
   it("renders the Event Heading in the EventCards", () => {
+    const mockAxios = new MockAdapter(axios, { delayResponse: 500 });
+    mockAxios.onGet("/api/events/").reply(200, mockEvents);
+
     render(
       <MemoryRouter>
         <EventCards />

--- a/src/components/EventCards/EventCards.tsx
+++ b/src/components/EventCards/EventCards.tsx
@@ -65,9 +65,9 @@ export const EventCards: FunctionComponent = () => {
     return (
       <Grid item xs={12} md={3} sm={6}>
         <EventCard
-          eventName={event.name}
-          eventDescription={event.tags.map((tag) => tag.name).join(",")}
-          eventStartDate={event.start_time}
+          name={event.name}
+          description={event.tags.join(", ")}
+          startDate={event.start_time}
           key={event.name}
         />
       </Grid>

--- a/src/components/EventCards/EventCards.tsx
+++ b/src/components/EventCards/EventCards.tsx
@@ -1,87 +1,62 @@
-import { Grid, Paper, Typography } from "@material-ui/core";
+import { CircularProgress, Grid, Paper, Typography } from "@material-ui/core";
 import axios from "axios";
-import MockAdapter from "axios-mock-adapter";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { WeBetEvent } from "../../models";
 import { useStyles } from "../../useStyle";
 import { EventCard } from "../EventCard";
 
-const eventsFromApi: WeBetEvent[] = [
-  {
-    name: "Summerslam",
-    start_time: "2021-03-01:20:00:00",
-    end_time: "2021-03-01:24:00:00",
-    tags: [
-      {
-        name: "WWE",
-      },
-      {
-        name: "PPV",
-      },
-    ],
-  },
-  {
-    name: "Hell in A Cell",
-    start_time: "2021-04-01:20:00:00",
-    end_time: "2021-04-01:24:00:00",
-    tags: [
-      {
-        name: "WWE",
-      },
-      {
-        name: "PPV",
-      },
-    ],
-  },
-  {
-    name: "Wrestlemania",
-    start_time: "2021-05-01:20:00:00",
-    end_time: "2021-05-01:24:00:00",
-    tags: [
-      {
-        name: "WWE",
-      },
-      {
-        name: "PPV",
-      },
-    ],
-  },
-];
-
 export const EventCards: FunctionComponent = () => {
   const classes = useStyles();
+  const [loading, setLoading] = useState(true);
+  const [errorOccurred, setErrorOccurred] = useState(false);
   const [events, setEvents] = useState<WeBetEvent[] | []>([]);
 
-  const mockAxios = new MockAdapter(axios, { delayResponse: 500 });
-  mockAxios.onGet("/fake/path").reply(200, eventsFromApi);
-
   useEffect(() => {
-    axios.get("/fake/path").then((response) => {
-      setEvents(response.data);
-    });
-  });
+    setLoading(true);
+    setErrorOccurred(false);
 
-  const cards = events.map((event: WeBetEvent) => {
-    return (
-      <Grid item xs={12} md={3} sm={6}>
-        <EventCard
-          name={event.name}
-          description={event.tags.join(", ")}
-          startDate={event.start_time}
-          key={event.name}
-        />
+    axios
+      .get<WeBetEvent[]>("/api/events/")
+      .then((response) => {
+        setEvents(response.data);
+      })
+      .catch((error) => {
+        console.error(error);
+        setErrorOccurred(true);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  let content = <CircularProgress />;
+  if (errorOccurred) {
+    content = <div>Something went wrong</div>;
+  } else if (!loading && events !== undefined && events !== null) {
+    const cards = events.map((event: WeBetEvent) => {
+      return (
+        <Grid item xs={12} md={3} sm={6} key={event.id}>
+          <EventCard
+            name={event.name}
+            description={event.tags.join(", ")}
+            startDate={event.start_time}
+            id={event.id}
+          />
+        </Grid>
+      );
+    });
+
+    content = (
+      <Grid container spacing={3}>
+        {cards}
       </Grid>
     );
-  });
+  }
 
   return (
     <Paper className={classes.paper}>
       <Typography variant="h2" gutterBottom>
         Events
       </Typography>
-      <Grid container spacing={3}>
-        {cards}
-      </Grid>
+      {content}
     </Paper>
   );
 };

--- a/src/components/MatchCard/MatchCard.test.tsx
+++ b/src/components/MatchCard/MatchCard.test.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MatchCard } from "./MatchCard";
+import { MemoryRouter } from "react-router-dom";
+
+describe("MatchCard", () => {
+  it("renders the Event name and description", () => {
+    render(
+      <MemoryRouter>
+        <MatchCard name="Fake Name" description="Fake Description" id={1} eventId={1} />
+      </MemoryRouter>
+    );
+
+    const MatchNameElement = screen.getByText(/Fake Name/);
+    const MatchDescriptionElement = screen.getByText(/Fake Description/);
+    expect(MatchNameElement).toBeInTheDocument();
+    expect(MatchDescriptionElement).toBeInTheDocument();
+  });
+});

--- a/src/components/MatchCard/MatchCard.tsx
+++ b/src/components/MatchCard/MatchCard.tsx
@@ -7,19 +7,25 @@ import CardContent from "@material-ui/core/CardContent";
 import Typography from "@material-ui/core/Typography";
 import { useStyles } from "../../useStyle";
 
-interface EventCardProps {
+interface MatchCardProps {
   name: string;
-  description: string;
-  startDate?: string;
+  description: string | JSX.Element;
   id: number;
+  eventId: number;
+  startDate?: string;
 }
 
-export const EventCard: FunctionComponent<EventCardProps> = ({ name, description, id }) => {
+export const MatchCard: FunctionComponent<MatchCardProps> = ({
+  name,
+  description,
+  id,
+  eventId,
+}) => {
   const classes = useStyles();
-  const eventDetailsUrl = `/event/${id}`;
+  const matchDetailsUrl = `/event/${eventId}/match/${id}`;
 
   return (
-    <Card className={classes.eventCard}>
+    <Card className={classes.matchCard}>
       <CardContent>
         <Typography variant="h5" component="h3">
           {name}
@@ -29,7 +35,7 @@ export const EventCard: FunctionComponent<EventCardProps> = ({ name, description
         </Typography>
       </CardContent>
       <CardActions>
-        <Button size="small" component={RouterLink} to={eventDetailsUrl}>
+        <Button size="small" component={RouterLink} to={matchDetailsUrl}>
           Details
         </Button>
       </CardActions>

--- a/src/components/MatchCard/MatchCard.tsx
+++ b/src/components/MatchCard/MatchCard.tsx
@@ -30,7 +30,7 @@ export const MatchCard: FunctionComponent<MatchCardProps> = ({
         <Typography variant="h5" component="h3">
           {name}
         </Typography>
-        <Typography variant="body2" color="textSecondary" component="p">
+        <Typography variant="body2" color="textSecondary" component="div">
           {description}
         </Typography>
       </CardContent>

--- a/src/components/MatchCard/index.ts
+++ b/src/components/MatchCard/index.ts
@@ -1,0 +1,1 @@
+export * from "./MatchCard";

--- a/src/components/MatchCards/MatchCards.test.tsx
+++ b/src/components/MatchCards/MatchCards.test.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+import { MatchCards } from "./MatchCards";
+import { MemoryRouter } from "react-router-dom";
+import { mockMatches } from "../../mockData/mockMatches";
+
+describe("EventCards", () => {
+  it("renders the Event Heading in the EventCards", () => {
+    const mockAxios = new MockAdapter(axios, { delayResponse: 500 });
+    mockAxios.onGet("/api/matches").reply(200, mockMatches);
+
+    render(
+      <MemoryRouter>
+        <MatchCards eventId={1} />
+      </MemoryRouter>
+    );
+    const MatchHeadingElement = screen.getByText(/Matches/i);
+    expect(MatchHeadingElement).toBeInTheDocument();
+  });
+});

--- a/src/components/MatchCards/MatchCards.tsx
+++ b/src/components/MatchCards/MatchCards.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useEffect, useState } from "react";
-import { Grid, Paper, Typography } from "@material-ui/core";
+import { CircularProgress, Grid, Paper, Typography } from "@material-ui/core";
 import axios from "axios";
 import { Match } from "../../models";
 import { useStyles } from "../../useStyle";
@@ -11,9 +11,14 @@ export interface MatchCardsProps {
 
 export const MatchCards: FunctionComponent<MatchCardsProps> = ({ eventId }) => {
   const classes = useStyles();
+  const [loading, setLoading] = useState(true);
+  const [errorOccurred, setErrorOccurred] = useState(false);
   const [matches, setMatches] = useState<Match[] | []>([]);
 
   useEffect(() => {
+    setLoading(true);
+    setErrorOccurred(false);
+
     axios
       .get<Match[]>("/api/matches", {
         params: {
@@ -22,38 +27,52 @@ export const MatchCards: FunctionComponent<MatchCardsProps> = ({ eventId }) => {
       })
       .then((response) => {
         setMatches(response.data);
-      });
+      })
+      .catch((error) => {
+        console.error(error);
+        setErrorOccurred(true);
+      })
+      .finally(() => setLoading(false));
   }, [eventId]);
 
-  const cards = matches.map((match: Match) => {
-    const matchDescription = (
-      <div>
-        {match.tags.join(", ")}
-        <p>{match.notes}</p>
-      </div>
-    );
+  let content = <CircularProgress />;
+  if (errorOccurred) {
+    content = <div>Something went wrong</div>;
+  } else if (!loading && matches !== undefined && matches !== null) {
+    const cards = matches.map((match: Match) => {
+      const matchDescription = (
+        <div>
+          {match.tags.join(", ")}
+          <p>{match.notes}</p>
+        </div>
+      );
 
-    return (
-      <Grid item xs={12} md={3} sm={6} key={match.id}>
-        <MatchCard
-          id={match.id}
-          name={match.name}
-          description={matchDescription}
-          startDate={match.start_time}
-          eventId={match.event}
-        />
+      return (
+        <Grid item xs={12} md={3} sm={6} key={match.id}>
+          <MatchCard
+            id={match.id}
+            name={match.name}
+            description={matchDescription}
+            startDate={match.start_time}
+            eventId={match.event}
+          />
+        </Grid>
+      );
+    });
+
+    content = (
+      <Grid container spacing={3}>
+        {cards}
       </Grid>
     );
-  });
+  }
 
   return (
     <Paper className={classes.paper}>
       <Typography variant="h2" gutterBottom>
         Matches
       </Typography>
-      <Grid container spacing={3}>
-        {cards}
-      </Grid>
+      {content}
     </Paper>
   );
 };

--- a/src/components/MatchCards/MatchCards.tsx
+++ b/src/components/MatchCards/MatchCards.tsx
@@ -1,0 +1,59 @@
+import React, { FunctionComponent, useEffect, useState } from "react";
+import { Grid, Paper, Typography } from "@material-ui/core";
+import axios from "axios";
+import { Match } from "../../models";
+import { useStyles } from "../../useStyle";
+import { MatchCard } from "../MatchCard";
+
+export interface MatchCardsProps {
+  eventId: number;
+}
+
+export const MatchCards: FunctionComponent<MatchCardsProps> = ({ eventId }) => {
+  const classes = useStyles();
+  const [matches, setMatches] = useState<Match[] | []>([]);
+
+  useEffect(() => {
+    axios
+      .get<Match[]>("/api/matches", {
+        params: {
+          event: eventId,
+        },
+      })
+      .then((response) => {
+        setMatches(response.data);
+      });
+  }, [eventId]);
+
+  const cards = matches.map((match: Match) => {
+    const matchDescription = (
+      <div>
+        {match.tags.join(", ")}
+        <p>{match.notes}</p>
+      </div>
+    );
+
+    return (
+      <Grid item xs={12} md={3} sm={6} key={match.id}>
+        <MatchCard
+          id={match.id}
+          name={match.name}
+          description={matchDescription}
+          startDate={match.start_time}
+          eventId={match.event}
+        />
+      </Grid>
+    );
+  });
+
+  return (
+    <Paper className={classes.paper}>
+      <Typography variant="h2" gutterBottom>
+        Matches
+      </Typography>
+      <Grid container spacing={3}>
+        {cards}
+      </Grid>
+    </Paper>
+  );
+};

--- a/src/components/MatchCards/index.ts
+++ b/src/components/MatchCards/index.ts
@@ -1,0 +1,1 @@
+export * from "./MatchCards";

--- a/src/mockData/mockEvents.ts
+++ b/src/mockData/mockEvents.ts
@@ -1,0 +1,25 @@
+import { WeBetEvent } from "../models";
+
+export const mockEvents: WeBetEvent[] = [
+  {
+    id: 1,
+    name: "Summerslam",
+    start_time: "2021-03-01:20:00:00",
+    end_time: "2021-03-01:24:00:00",
+    tags: ["WWE", "PPV"],
+  },
+  {
+    id: 2,
+    name: "Hell in A Cell",
+    start_time: "2021-04-01:20:00:00",
+    end_time: "2021-04-01:24:00:00",
+    tags: ["WWE", "PPV"],
+  },
+  {
+    id: 3,
+    name: "Wrestlemania",
+    start_time: "2021-05-01:20:00:00",
+    end_time: "2021-05-01:24:00:00",
+    tags: ["WWE", "PPV"],
+  },
+];

--- a/src/mockData/mockMatches.ts
+++ b/src/mockData/mockMatches.ts
@@ -1,0 +1,16 @@
+import { Match } from "../models";
+
+export const mockMatches: Match[] = [
+  {
+    id: 1,
+    name: "Undertaker vs John Cena",
+    start_time: "2021-03-21T18:00:00Z",
+    status: "open",
+    bet_type: "one",
+    notes:
+      "Are you ready for this Sunday night when WWE champ John Cena defends his title in the WWE Super Slam? Right now you can order this awesome pay-per-view event for just $59.99!",
+    results: null,
+    event: 1,
+    tags: ["Main Event"],
+  },
+];

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -1,6 +1,5 @@
-export interface Tag {
-  name: string;
-}
+export type Tag = string;
+
 export interface WeBetEvent {
   name: string;
   start_time: string;

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -1,6 +1,7 @@
 export type Tag = string;
 
 export interface WeBetEvent {
+  id: number;
   name: string;
   start_time: string;
   end_time: string;

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -54,13 +54,15 @@ export interface EventUser {
 }
 
 export interface Match {
-  event: WeBetEvent;
+  id: number;
+  event: number; // Id of event
   name: string;
   start_time: string;
   status: string;
   bet_type: string;
   notes: string;
-  results: {};
+  results?: { [key: string]: any } | null;
+  tags: Tag[];
 }
 
 export interface MatchTeam {

--- a/src/pages/EventDetails.tsx
+++ b/src/pages/EventDetails.tsx
@@ -1,0 +1,76 @@
+import { CircularProgress, Container, Grid, Paper, Typography } from "@material-ui/core";
+import React, { FunctionComponent, useEffect, useState } from "react";
+import { useStyles } from "../useStyle";
+import { WeBetEvent } from "../models";
+import axios from "axios";
+import { useParams } from "react-router-dom";
+import { MatchCards } from "../components/MatchCards";
+
+interface DetailsProps {
+  event: WeBetEvent;
+}
+
+const Details: FunctionComponent<DetailsProps> = ({ event }) => {
+  const classes = useStyles();
+
+  return (
+    <Paper className={classes.paper}>
+      <Typography variant="h1" component="h1" gutterBottom>
+        {event.name}
+      </Typography>
+      <Typography variant="body2" color="textSecondary" component="p">
+        <strong>Start time: </strong>
+        {event.start_time}
+      </Typography>
+      <Typography variant="body2" color="textSecondary" component="p">
+        <strong>Tags: </strong>
+        {event.tags.join(", ")}
+      </Typography>
+    </Paper>
+  );
+};
+
+export const EventDetails: FunctionComponent = () => {
+  const classes = useStyles();
+  const { id } = useParams<Record<"id", string>>();
+  const [loading, setLoading] = useState(true);
+  const [event, setEvent] = useState<WeBetEvent>();
+  const [errorOccurred, setErrorOccurred] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    setErrorOccurred(false);
+    axios
+      .get<WeBetEvent>(`/api/events/${id}`)
+      .then((response) => {
+        setEvent(response.data);
+      })
+      .catch((error) => {
+        console.error(error);
+        setErrorOccurred(true);
+      })
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  let content = <CircularProgress />;
+  if (errorOccurred) {
+    content = <div>Something Went Wrong</div>;
+  } else if (!loading && event !== undefined && event !== null) {
+    content = (
+      <Grid container spacing={3}>
+        <Grid item xs={12}>
+          <Details event={event} />
+        </Grid>
+        <Grid item xs={12}>
+          <MatchCards eventId={event.id} />
+        </Grid>
+      </Grid>
+    );
+  }
+
+  return (
+    <Container maxWidth="lg" className={classes.container}>
+      {content}
+    </Container>
+  );
+};

--- a/src/pages/EventsList.tsx
+++ b/src/pages/EventsList.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent, useEffect, useState } from "react";
 import axios from "axios";
-import MockAdapter from "axios-mock-adapter";
 import { DataGrid, GridColDef } from "@material-ui/data-grid";
 import EditIcon from "@material-ui/icons/Edit";
 import DeleteIcon from "@material-ui/icons/Delete";
@@ -19,7 +18,7 @@ const columns: GridColDef[] = [
     flex: 1,
     valueFormatter: (params) => {
       const tags = params.value as Tag[];
-      return tags.map((tag) => tag.name).join(", ");
+      return tags.join(", ");
     },
   },
   {
@@ -42,64 +41,32 @@ const columns: GridColDef[] = [
   },
 ];
 
-const eventsFromApi: WeBetEvent[] = [
-  {
-    name: "Summerslam",
-    start_time: "2021-03-01:20:00:00",
-    end_time: "2021-03-01:24:00:00",
-    tags: [
-      {
-        name: "WWE",
-      },
-      {
-        name: "PPV",
-      },
-    ],
-  },
-  {
-    name: "Hell in A Cell",
-    start_time: "2021-04-01:20:00:00",
-    end_time: "2021-04-01:24:00:00",
-    tags: [
-      {
-        name: "WWE",
-      },
-      {
-        name: "PPV",
-      },
-    ],
-  },
-  {
-    name: "Wrestlemania",
-    start_time: "2021-05-01:20:00:00",
-    end_time: "2021-05-01:24:00:00",
-    tags: [
-      {
-        name: "WWE",
-      },
-      {
-        name: "PPV",
-      },
-    ],
-  },
-];
-
 export const EventList: FunctionComponent = () => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [events, setEvents] = useState<WeBetEvent[] | []>([]);
 
-  const mockAxios = new MockAdapter(axios, { delayResponse: 500 });
-  mockAxios.onGet("/fake/path").reply(200, eventsFromApi);
-
   useEffect(() => {
-    axios.get("/fake/path").then((response) => {
-      setEvents(response.data);
-    });
-  });
+    setLoading(true);
+    setError(null);
+    axios
+      .get<WeBetEvent[]>("/api/events")
+      .then((response) => {
+        setEvents(response.data);
+      })
+      .catch((error) => {
+        console.error(error);
+        setError(error);
+      })
+      .finally(() => setLoading(false));
+  }, []);
 
   return (
     <div style={{ display: "flex", height: "100%" }}>
       <div style={{ flexGrow: 1 }}>
         <DataGrid
+          loading={loading}
+          error={error}
           rows={events}
           columns={columns}
           pageSize={5}

--- a/src/useStyle.ts
+++ b/src/useStyle.ts
@@ -35,8 +35,7 @@ export const useStyles = makeStyles((theme: Theme) =>
     nested: {
       paddingLeft: theme.spacing(4),
     },
-    eventCard: {
-      // minWidth: 275,
-    },
+    eventCard: {},
+    matchCard: {},
   })
 );


### PR DESCRIPTION
## Description
Changes the text of the event card to "Details" and makes it a link to a details page that displays more info about the event and lists the matches in that event.

Also does some refactoring of EventCard and fixes the Tag type to match what the API is going to provide for them.

closes #63 

## Screenshots

Event card now shows "Details" at the bottom, which is a link to the details page:
![WeBet events 2021-05-04 005700](https://user-images.githubusercontent.com/14079950/116965801-493f4880-ac74-11eb-9449-9f31ef670180.png)

Event details page:
![WeBet events details2021-05-04 005742](https://user-images.githubusercontent.com/14079950/116965800-493f4880-ac74-11eb-9c3d-9658d3dbb6b6.png)

